### PR TITLE
Use importlib.spec for optional modules and clean imports

### DIFF
--- a/src/batch/report.py
+++ b/src/batch/report.py
@@ -9,6 +9,7 @@ Ansa批处理结果解析和报告生成模块
 功能: 从 batch_mesh.py 中提取的报告生成逻辑
 """
 
+import importlib.util
 import logging
 import time
 from pathlib import Path
@@ -16,14 +17,8 @@ from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
-# 安全导入Ansa模块
-ANSA_AVAILABLE = False
-try:
-    from ansa import base, constants, mesh
-
-    ANSA_AVAILABLE = True
-except ImportError:
-    pass
+# 检测 Ansa 模块可用性
+ANSA_AVAILABLE = importlib.util.find_spec("ansa") is not None
 
 
 class QualityReportGenerator:

--- a/src/batch/runner.py
+++ b/src/batch/runner.py
@@ -13,7 +13,7 @@ import logging
 import time
 import traceback
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from .config import AnsaBatchConfig
 

--- a/src/batch_mesh.py
+++ b/src/batch_mesh.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import logging
 import sys
-import time
 import traceback
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -78,12 +77,8 @@ try:
         AnsaBatchConfig,
         AnsaBatchMeshRunner,
         QualityReportGenerator,
-        ResultAnalyzer,
         create_default_config,
         load_config_from_file,
-        run_batch_mesh as run_batch_mesh_simple,
-        check_element_quality_simple,
-        generate_quality_report,
         analyze_quality_results,
     )
 except ImportError:
@@ -93,25 +88,10 @@ except ImportError:
         AnsaBatchConfig,
         AnsaBatchMeshRunner,
         QualityReportGenerator,
-        ResultAnalyzer,
         create_default_config,
         load_config_from_file,
-        run_batch_mesh as run_batch_mesh_simple,
-        check_element_quality_simple,
-        generate_quality_report,
         analyze_quality_results,
     )
-
-# 安全导入Ansa模块
-ANSA_AVAILABLE = False
-try:
-    from ansa import base, constants, mesh
-
-    ANSA_AVAILABLE = True
-    logger.info("Ansa模块加载成功")
-except ImportError as e:
-    logger.warning(f"Ansa模块未找到: {e}")
-    logger.info("将使用模拟模式运行")
 
 # 为了向后兼容，重新导出类
 AnsaBatchConfig = AnsaBatchConfig

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -3,6 +3,6 @@ CLI模块 - 命令行接口组件
 """
 
 from .cli_main import create_parser, main_cli
-from .commands import *
+from .commands import *  # noqa: F403
 
 __all__ = ["create_parser", "main_cli"]

--- a/src/cli/cli_main.py
+++ b/src/cli/cli_main.py
@@ -11,7 +11,7 @@ import logging
 # 导入统一的日志配置
 from ..utils.logging_config import setup_cli_logging
 # 导入统一的版本号
-from .. import __version__, APP_VERSION, APP_NAME
+from .. import APP_VERSION, APP_NAME
 
 logger = logging.getLogger(__name__)
 

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -9,6 +9,7 @@
 功能: 提供简化的配置管理，减少复杂性，保持向后兼容性
 """
 
+import importlib.util
 import json
 import logging
 from dataclasses import dataclass, field
@@ -89,12 +90,8 @@ class SimpleOptimizationConfig:
         """获取可用的优化器列表"""
         available = ["random", "genetic"]
 
-        try:
-            import skopt
-
+        if importlib.util.find_spec("skopt") is not None:
             available.extend(["bayesian", "forest"])
-        except ImportError:
-            pass
 
         return available
 

--- a/src/core/ansa_mesh_optimizer.py
+++ b/src/core/ansa_mesh_optimizer.py
@@ -84,8 +84,8 @@ try:
     logger.info("配置系统类已导入")
 
     # 导入重构后的模块
-    from .early_stopping import EarlyStopping, create_early_stopping
-    from ..evaluators.mesh_evaluator import MeshEvaluator, create_mesh_evaluator
+    from .early_stopping import create_early_stopping
+    from ..evaluators.mesh_evaluator import create_mesh_evaluator
 
     # 导入新的优化器策略模块
     from ..optimizers import (
@@ -97,7 +97,6 @@ try:
     from ..reports.optimization_reporter import OptimizationReporter
     from ..utils import performance_monitor
     from ..utils.optimization_cache import CachedEvaluator, OptimizationCache
-    from ..utils.utils import normalize_params, validate_param_types
 
     # 导入可视化和报告模块
     from ..visualization.optimization_visualizer import OptimizationVisualizer
@@ -351,7 +350,7 @@ class MeshOptimizer:
                 logger.info(f"分析参数: {param_name}")
 
                 # 确定参数类型并设置合适的扰动范围
-                if param_type == float:
+                if param_type is float:
                     min_val = max(low, param_value * (1 - noise_level))
                     max_val = min(high, param_value * (1 + noise_level))
                     test_values = np.linspace(min_val, max_val, n_trials)

--- a/src/core/compare_optimizers.py
+++ b/src/core/compare_optimizers.py
@@ -19,6 +19,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+import importlib.util
 
 # 配置日志
 logger = logging.getLogger(__name__)
@@ -26,7 +27,6 @@ logger = logging.getLogger(__name__)
 # 安全导入分析库
 ANALYSIS_LIBS_AVAILABLE = False
 try:
-    import numpy as np
     import pandas as pd
 
     ANALYSIS_LIBS_AVAILABLE = True
@@ -41,20 +41,14 @@ except ImportError as e:
 
     pd = MockPandas()
 
-# 尝试导入统计库
-SCIPY_AVAILABLE = False
-try:
-    from scipy import stats
-
-    SCIPY_AVAILABLE = True
-except ImportError:
-    logger.warning("scipy不可用，将跳过高级统计分析")
+# 检测统计库可用性
+SCIPY_AVAILABLE = importlib.util.find_spec("scipy") is not None
 
 # 本地模块导入
 try:
     from ..analysis.statistical_analyzer import StatisticalAnalyzer
     from ..config.config import UnifiedConfigManager
-    from .ansa_mesh_optimizer import MeshOptimizer, optimize_mesh_parameters
+    from .ansa_mesh_optimizer import MeshOptimizer
     from ..reports.comparison_reporter import ComparisonReporter
     from ..utils import (
         calculate_statistics,

--- a/src/evaluators/mesh_evaluator.py
+++ b/src/evaluators/mesh_evaluator.py
@@ -15,7 +15,6 @@ import logging
 import random
 import time
 from abc import ABC, abstractmethod
-from pathlib import Path
 from typing import Dict
 
 # 导入新的专用模块
@@ -30,9 +29,6 @@ from .environment import AnsaEnvironmentValidator
 from .parameter_replacement_strategies import (
     ParameterReplacementManager,
 )
-
-# 导入重构后的工具模块
-from .utils import normalize_params
 
 logger = logging.getLogger(__name__)
 

--- a/src/optimizers/evolution.py
+++ b/src/optimizers/evolution.py
@@ -414,7 +414,7 @@ def gaussian_mutation(
         if random.random() < mutation_rate:
             low, high = individual.bounds[i]
 
-            if individual.param_types[i] == int:
+            if individual.param_types[i] is int:
                 # 整数变异
                 range_size = max(1, int((high - low) * mutation_strength))
                 delta = random.randint(-range_size, range_size)

--- a/src/optimizers/genetic_visualization.py
+++ b/src/optimizers/genetic_visualization.py
@@ -18,7 +18,7 @@ try:
     import matplotlib.pyplot as plt
     import numpy as np
 
-    from ..utils.display_config import DisplayConfig, display_config
+    from ..utils.display_config import DisplayConfig
 
     MATPLOTLIB_AVAILABLE = True
 

--- a/src/optimizers/individual.py
+++ b/src/optimizers/individual.py
@@ -47,7 +47,7 @@ class Individual:
         for i, (gene, (low, high), param_type) in enumerate(
             zip(self.genes, self.bounds, self.param_types)
         ):
-            if param_type == int:
+            if param_type is int:
                 self.genes[i] = max(low, min(high, round(gene)))
             else:
                 self.genes[i] = max(low, min(high, gene))
@@ -56,7 +56,7 @@ class Individual:
         """转换为参数字典"""
         params = {}
         for i, name in enumerate(param_names):
-            if self.param_types[i] == int:
+            if self.param_types[i] is int:
                 params[name] = int(round(self.genes[i]))
             else:
                 params[name] = self.genes[i]
@@ -80,7 +80,7 @@ class Individual:
             if random.random() < adaptive_rate:
                 low, high = self.bounds[i]
 
-                if self.param_types[i] == int:
+                if self.param_types[i] is int:
                     # 整数变异
                     range_size = max(1, int((high - low) * 0.1))
                     delta = random.randint(-range_size, range_size)
@@ -119,7 +119,7 @@ class Individual:
         child2_genes = []
 
         for i in range(len(self.genes)):
-            if self.param_types[i] == int:
+            if self.param_types[i] is int:
                 # 整数参数使用均匀交叉
                 if random.random() < 0.5:
                     child1_genes.append(self.genes[i])
@@ -216,7 +216,7 @@ def create_individual(
     """
     genes = []
     for (low, high), param_type in zip(bounds, param_types):
-        if param_type == int:
+        if param_type is int:
             gene = random.randint(int(low), int(high))
         else:
             gene = random.uniform(low, high)

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -154,9 +154,6 @@ __all__ = [
     "PATTERNS",
 ]
 
-# 从主包导入版本信息
-from src import __version__, __author__
-
 # 模块说明
 __doc_modules__ = {
     "utils": "参数验证和类型转换",

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -22,11 +22,11 @@ from typing import Any, Dict, Union
 
 import numpy as np
 
-logger = logging.getLogger(__name__)
-
 # 导入统一的参数验证功能
 from .parameter_validator import normalize_params as _normalize_params
 from .parameter_validator import validate_param_types as _validate_param_types
+
+logger = logging.getLogger(__name__)
 
 
 def normalize_params(params: Dict[str, Any]) -> Dict[str, Union[int, float]]:


### PR DESCRIPTION
## Summary
- detect ANSA availability with `importlib.util.find_spec` in batch report generation
- reorder `parameter_validator` imports before module code in utilities
- drop unused package metadata imports and general lint cleanup across codebase

## Testing
- `ruff check src`
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy'; No module named 'ansa_mesh_optimizer')*

------
https://chatgpt.com/codex/tasks/task_e_68aad8a4a47c8322bd6b3789ae75a4af