### PR TITLE
Use relative imports for CLI command modules

### DIFF
--- a/src/cli/cli_main.py
+++ b/src/cli/cli_main.py
@@ -72,8 +72,8 @@ def create_parser() -> argparse.ArgumentParser:
             logger.debug("动态加载命令模块: %s", module_name)
 
             # 构建完整的模块路径并动态导入
-            full_module_path = f"src.cli.commands.{module_name}"
-            module = importlib.import_module(full_module_path)
+            full_module_path = f".commands.{module_name}"
+            module = importlib.import_module(full_module_path, package=__package__)
 
             # 获取注册函数并调用
             register_func = getattr(module, register_func_name)


### PR DESCRIPTION
## Summary
- adjust CLI command loading to use relative imports and package context

## Testing
- `python - <<'PY'
from src.cli.cli_main import create_parser
p = create_parser()
print(sorted(p._subparsers._group_actions[0].choices.keys()))
PY`
- `pytest` (fails: 49 failed, 229 passed)

------
https://chatgpt.com/codex/tasks/task_e_68ab145036b48322aa17c05cd60dff1f