### PR TITLE
Simplify CLI logging setup

### DIFF
--- a/src/cli/cli_main.py
+++ b/src/cli/cli_main.py
@@ -92,17 +92,13 @@ def main_cli() -> int:
     """主CLI函数"""
     parser = create_parser()
     args = parser.parse_args()
-
-    # 设置日志级别
-    if args.quiet:
-        pass
-    elif args.verbose:
-        pass
-    else:
-        pass
-
     # 设置日志
-    setup_cli_logging(args.verbose, args.log_file)
+    setup_cli_logging(args.verbose and not args.quiet, args.log_file)
+
+    if args.quiet:
+        logging.getLogger().setLevel(logging.ERROR)
+    elif args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
 
     # 检查命令
     if not args.command:


### PR DESCRIPTION
## Summary
- initialize CLI logging once in `main_cli`
- adjust root logger level based on `--quiet` or `--verbose`

## Testing
- `pre-commit run --files src/cli/cli_main.py` *(fails: RPC failed; HTTP 403 curl 22 The requested URL returned error: 403)*
- `pytest` *(fails: 49 failed, 229 passed, 11 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ab156e1cd083228bfcd3f8039cc584