### PR TITLE
fix: isolate logging config instances

### DIFF
--- a/src/utils/logging_config.py
+++ b/src/utils/logging_config.py
@@ -15,6 +15,7 @@ import json
 import logging
 import logging.handlers
 import sys
+import copy
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
@@ -73,7 +74,7 @@ class LoggingConfig:
 
     def _merge_config(self, user_config: Dict[str, Any]) -> Dict[str, Any]:
         """合并用户配置和默认配置"""
-        config = self.DEFAULT_CONFIG.copy()
+        config = copy.deepcopy(self.DEFAULT_CONFIG)
 
         # 深度合并配置
         for key, value in user_config.items():

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Logging configuration tests."""
+
+from src.utils.logging_config import LoggingConfig
+
+
+def test_multiple_instances_independent():
+    """Ensure instances do not share mutable config."""
+    lc1 = LoggingConfig()
+    lc1.config["file"]["enabled"] = True
+    lc1.config["modules"]["custom"] = "DEBUG"
+
+    lc2 = LoggingConfig()
+
+    assert lc2.config["file"]["enabled"] is False
+    assert "custom" not in lc2.config["modules"]
+    assert LoggingConfig.DEFAULT_CONFIG["file"]["enabled"] is False
+    assert "custom" not in LoggingConfig.DEFAULT_CONFIG["modules"]
+


### PR DESCRIPTION
## Summary
- ensure logging configuration defaults are deep-copied
- add unit test verifying configuration isolation between instances

## Testing
- `pytest tests/unit/test_logging_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab16abed308322b81f742c6ec04cdf