### PR TITLE
fix: robust version imports for standalone modules

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -18,7 +18,13 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 # 导入统一的版本号
-from src import __version__
+try:
+    from .. import __version__
+except ImportError:  # pragma: no cover
+    import sys
+
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+    from src import __version__
 
 logger = logging.getLogger(__name__)
 

--- a/src/utils/optimization_cache.py
+++ b/src/utils/optimization_cache.py
@@ -24,7 +24,13 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
 # 导入统一的版本号
-from src import __version__
+try:
+    from .. import __version__
+except ImportError:  # pragma: no cover
+    import sys
+
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+    from src import __version__
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- ensure config and optimization cache import `__version__` with relative path and fallback

## Testing
- `pytest -q` *(fails: 49 failed, 230 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1935038083228b0a0fd1575dd227